### PR TITLE
Fix open file NULL access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 0.0.2
+
+## Fixed
+
+- Update extension-ci-tools to latest, which points to duckdb v1.4.4


### PR DESCRIPTION
This PR does a few things:
- (major) Fix a nullptr access issue: when open file returns nullptr, we should propagate it up directly
- (minor) Call `OpenFileExtended` inside of `OpenFile` to avoid code duplication
- (minor) Add the missing changelog from last upgrade PR